### PR TITLE
add cloudwatch log plugin to debian

### DIFF
--- a/v1.10/alpine/Dockerfile
+++ b/v1.10/alpine/Dockerfile
@@ -23,6 +23,7 @@ RUN apk update \
  && gem install ext_monitor -v 0.1.2 \
  && gem install fluentd -v 1.10.4 \
  && gem install bigdecimal -v 1.4.4 \
+ && gem install fluent-plugin-cloudwatch-logs -v 0.10.2 \
  && apk del .build-deps \
  && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
 

--- a/v1.10/alpine/Dockerfile
+++ b/v1.10/alpine/Dockerfile
@@ -23,7 +23,6 @@ RUN apk update \
  && gem install ext_monitor -v 0.1.2 \
  && gem install fluentd -v 1.10.4 \
  && gem install bigdecimal -v 1.4.4 \
- && gem install fluent-plugin-cloudwatch-logs -v 0.10.2 \
  && apk del .build-deps \
  && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
 

--- a/v1.10/debian/Dockerfile
+++ b/v1.10/debian/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get update \
     fluent-plugin-webhdfs \
     fluent-plugin-grok-parser \
     fluent-plugin-prometheus \
+    fluent-plugin-cloudwatch-logs \
  && gem sources --clear-all \
  && apt-get purge -y --auto-remove \
                   -o APT::AutoRemove::RecommendsImportant=false \


### PR DESCRIPTION
Add cloudwatch log plugin to alpine
Build image: https://us-west-1.console.aws.amazon.com/ecr/repositories/hzhao/fluentd/?region=us-west-1
Test in stage: https://github.com/ContextLogic/k8s/pull/3585
logs are successfully sent to aws cloudwatch log: https://us-west-1.console.aws.amazon.com/cloudwatch/home?region=us-west-1#logsV2:log-groups/log-group/mongoproxy_auditlog

FYI, right now, everyone can push and merge the pr.