### PR TITLE
Add AWS ES plugin which enables signing the request

### DIFF
--- a/v1.10/debian/Dockerfile
+++ b/v1.10/debian/Dockerfile
@@ -53,6 +53,7 @@ RUN apt-get update \
     fluent-plugin-grok-parser \
     fluent-plugin-prometheus \
     fluent-plugin-cloudwatch-logs \
+    fluent-plugin-aws-elasticsearch-service \
  && gem sources --clear-all \
  && apt-get purge -y --auto-remove \
                   -o APT::AutoRemove::RecommendsImportant=false \


### PR DESCRIPTION
To talk to an ElasticSearch cluster with fine grain access control enabled, we need to sign the request.
This plugin is necessary to assume role.